### PR TITLE
Use debug launch config to map local and remote source code paths.

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -261,10 +261,10 @@ async function getCodewindProjectFolders(): Promise<string[]> {
   const workspaceFolders: WorkspaceFolder[] = await connection.workspace.getWorkspaceFolders();
   const cwProjectFolders: string[] = [];
   for ( const folder of workspaceFolders) {
-    connection.console.log('getMicrocliamteProjectFolders - found folder: ' + inspect(folder));
+    connection.console.log('getCodewindProjectFolders - found folder: ' + inspect(folder));
     const url: URL = new URL(folder.uri);
     const pathname: string = url.pathname;
-    connection.console.log('Pathname is: ' + pathname);
+    connection.console.log('getCodewindProjectFolders - pathname is: ' + pathname);
 
     const workspaceProjectFolders: string[] = await searchForFolders(pathname, settings.profilingfolder);
     cwProjectFolders.push(...workspaceProjectFolders);
@@ -303,7 +303,7 @@ async function searchForFolders(pathname: string, name: string): Promise<string[
 
 async function highlightFunctions(textDocument: TextDocumentItem, profilingPath: string): Promise<void> {
   try {
-    const diagnostics: Diagnostic[] = profilingManager.getDiagnosticsForFile(
+    const diagnostics: Diagnostic[] = await profilingManager.getDiagnosticsForFile(
       textDocument.uri, profilingPath, projectFolders, hasDiagnosticRelatedInformationCapability,
     );
     highlightedTextDocuments.set(textDocument, diagnostics);


### PR DESCRIPTION
Use the debug launch configuration information to map the local and remote source roots instead of assuming remote source is under /app.

The codewind-vscode plugin generates a debug launch configuration for applications when the user attempts to debug them. I will see if we can start doing this when the project is created now we are also using that information to help highlight code that has profiled hot.

A launch config looks like this:
```
        {
            "type": "node",
            "name": "Debug nodeapp",
            "request": "attach",
            "address": "127.0.0.1",
            "port": 32776,
            "localRoot": "/Users/user1/work/codewind/codewind-workspace/nodeapp",
            "remoteRoot": "/app",
            "restart": true
        },
```

When the profiling plugin find results in:  `/Users/user1/work/codewind/codewind-workspace/nodeapp/load-test` it will look in the available debug launch configs for one with a localRoot of `/Users/user1/work/codewind/codewind-workspace/` if found it will then map the `remoteRoot` path in any of the the profiling results in `load-test` to the `localRoot` value when trying to work out which files to highlight results in.