### PR TITLE
Add IBM license

### DIFF
--- a/server/src/modules/ProfilingManager.ts
+++ b/server/src/modules/ProfilingManager.ts
@@ -1,11 +1,13 @@
 /*******************************************************************************
- * Licensed Materials - Property of IBM "Restricted Materials of IBM"
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
  *
- * Copyright IBM Corp. 2019 All Rights Reserved
- *
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
- ******************************************************************************/
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 
 import { readFileSync } from 'fs';
 import { inspect } from 'util';

--- a/server/src/modules/Tree.ts
+++ b/server/src/modules/Tree.ts
@@ -1,11 +1,13 @@
 /*******************************************************************************
- * Licensed Materials - Property of IBM "Restricted Materials of IBM"
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
  *
- * Copyright IBM Corp. 2018 All Rights Reserved
- *
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
- ******************************************************************************/
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 
 import TreeNode from './TreeNode';
 import { TreeNodeMap } from './types';

--- a/server/src/modules/TreeNode.ts
+++ b/server/src/modules/TreeNode.ts
@@ -1,11 +1,13 @@
 /*******************************************************************************
- * Licensed Materials - Property of IBM "Restricted Materials of IBM"
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
  *
- * Copyright IBM Corp. 2019 All Rights Reserved
- *
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
- ******************************************************************************/
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 
 export default class TreeNode {
 

--- a/server/src/modules/config.ts
+++ b/server/src/modules/config.ts
@@ -1,1 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 export const shortName: string = 'Codewind Profiling';

--- a/server/src/modules/types.ts
+++ b/server/src/modules/types.ts
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 import TreeNode from './TreeNode';
 
 export type TreeNodeMap = Map<number | string, TreeNode>;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,11 +1,13 @@
 /*******************************************************************************
- * Licensed Materials - Property of IBM "Restricted Materials of IBM"
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
  *
- * Copyright IBM Corp. 2018 All Rights Reserved
- *
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
- ******************************************************************************/
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 import { inspect } from 'util';
 
 import * as fs from 'fs-extra';

--- a/vscode/client/src/extension.ts
+++ b/vscode/client/src/extension.ts
@@ -1,11 +1,13 @@
 /*******************************************************************************
- * Licensed Materials - Property of IBM "Restricted Materials of IBM"
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
  *
- * Copyright IBM Corp. 2018 All Rights Reserved
- *
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
- ******************************************************************************/
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 
 import * as path from 'path';
 import {

--- a/vscode/client/src/test/diagnostics.test.ts
+++ b/vscode/client/src/test/diagnostics.test.ts
@@ -1,11 +1,13 @@
-/********************************************************************************
- * Licensed Materials - Property of IBM "Restricted Materials of IBM"
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
  *
- * Copyright IBM Corp. 2019 All Rights Reserved
- *
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
- ******************************************************************************/
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 'use strict';
 
 import * as assert from 'assert';

--- a/vscode/client/src/test/helper.ts
+++ b/vscode/client/src/test/helper.ts
@@ -1,11 +1,13 @@
-/********************************************************************************
- * Licensed Materials - Property of IBM "Restricted Materials of IBM"
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
  *
- * Copyright IBM Corp. 2019 All Rights Reserved
- *
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
- ******************************************************************************/
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 'use strict';
 
 import * as path from 'path';

--- a/vscode/client/src/test/index.ts
+++ b/vscode/client/src/test/index.ts
@@ -1,11 +1,13 @@
-/********************************************************************************
- * Licensed Materials - Property of IBM "Restricted Materials of IBM"
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
  *
- * Copyright IBM Corp. 2019 All Rights Reserved
- *
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
- ******************************************************************************/
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 'use strict';
 
 import * as testRunner from 'vscode/lib/testrunner';


### PR DESCRIPTION
### Summary
* Change license header to IBM Eclipse one, add to file that didn't have it 

Signed-off-by: James Wallis <james.wallis1@ibm.com>